### PR TITLE
fix: ensure database parent directory exists before opening

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,8 +1,11 @@
 import { Database } from "bun:sqlite";
+import { mkdirSync } from "fs";
+import { dirname } from "path";
 
 let _db: Database | null = null;
 
 export function initDb(dbPath: string): Database {
+  mkdirSync(dirname(dbPath), { recursive: true });
   const db = new Database(dbPath, { create: true });
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA foreign_keys = ON");


### PR DESCRIPTION
## Summary
- `initDb` now creates the parent directory (e.g. `~/.config/engineering-notebook/`) before opening the SQLite database
- Fixes `SQLITE_CANTOPEN` (errno 14) on first run when the config directory doesn't exist yet
- Uses `mkdirSync` with `{ recursive: true }` to match the pattern already used in `saveConfig`

## Test plan
- [ ] Delete `~/.config/engineering-notebook/` and run `bun run src/index.ts ingest` — should succeed without error
- [ ] Run again with the directory already present — should still work (recursive mkdir is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)