### PR TITLE
feat: get username from sessions, fix Codex resume commands

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -10,6 +10,8 @@ describe("parseSession", () => {
     const session = parseSession(fixturePath);
     expect(session.sessionId).toBe("test-session-1");
     expect(session.projectPath).toBe("/Users/jesse/projects/myapp");
+    expect(session.userDisplayName).toBe("jesse");
+    expect(session.assistantDisplayName).toBe("Claude");
     expect(session.gitBranch).toBe("main");
     expect(session.version).toBe("2.1.25");
     expect(session.startedAt).toBeTruthy();
@@ -49,10 +51,10 @@ describe("parseSession", () => {
     const session = parseSession(fixturePath);
     const md = session.toMarkdown();
     expect(md).toContain("# Session: myapp");
-    expect(md).toContain("**User (2026-02-02 17:37):** Fix the login bug");
+    expect(md).toContain("**jesse (2026-02-02 17:37):** Fix the login bug");
     expect(md).toContain("**Claude (2026-02-02 17:37):** I'll investigate the login flow.");
     expect(md).toContain("**Claude (2026-02-02 17:38):** Found the bug.");
-    expect(md).toContain("**User (2026-02-02 17:39):** Great, fix it please");
+    expect(md).toContain("**jesse (2026-02-02 17:39):** Great, fix it please");
     expect(md).not.toContain("thinking");
     expect(md).not.toContain("tool_use");
     expect(md).not.toContain("tool_result");
@@ -67,6 +69,8 @@ describe("parseSession", () => {
     const session = parseSession(codexFixturePath);
     expect(session.sessionId).toBe("019bf429-646d-70c2-a8b8-a0d69db3f01d");
     expect(session.projectPath).toBe("/Users/peteror/Code/engineering-notebook");
+    expect(session.userDisplayName).toBe("peteror");
+    expect(session.assistantDisplayName).toBe("Codex");
     expect(session.version).toBe("0.99.0-alpha.23");
     expect(session.gitBranch).toBe("main");
   });
@@ -78,6 +82,12 @@ describe("parseSession", () => {
     expect(session.messages[0]?.text).toBe("Please add Codex support.");
     expect(session.messages[1]?.role).toBe("assistant");
     expect(session.messages[1]?.text).toContain("I'll add Codex support.");
+  });
+
+  test("uses Codex label in markdown for Codex sessions", () => {
+    const session = parseSession(codexFixturePath);
+    const md = session.toMarkdown();
+    expect(md).toContain("**Codex (2026-02-24 09:00):** I'll add Codex support.");
   });
 
   test("skips Codex bootstrap user messages", () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,6 +14,8 @@ export type ParsedSession = {
   parentSessionId: string | null;
   projectPath: string;
   projectName: string;
+  userDisplayName: string;
+  assistantDisplayName: string;
   gitBranch: string | null;
   version: string | null;
   startedAt: string;
@@ -45,6 +47,7 @@ type CodexRecord = {
   payload?: {
     id?: string;
     cwd?: string;
+    originator?: string;
     cli_version?: string;
     git?: {
       branch?: string;
@@ -70,6 +73,16 @@ type ContentBlock = {
 function projectNameFromPath(projectPath: string): string {
   const parts = projectPath.split("/").filter(Boolean);
   return parts[parts.length - 1] || "unknown";
+}
+
+function userDisplayNameFromPath(projectPath: string): string {
+  const unixHomeMatch = projectPath.match(/^\/(?:Users|home)\/([^/]+)/);
+  if (unixHomeMatch?.[1]) return unixHomeMatch[1];
+
+  const windowsHomeMatch = projectPath.match(/^[A-Za-z]:\\Users\\([^\\]+)/);
+  if (windowsHomeMatch?.[1]) return windowsHomeMatch[1];
+
+  return "User";
 }
 
 /** Format a UTC ISO timestamp to HH:MM using UTC hours/minutes */
@@ -146,6 +159,7 @@ export function parseSession(filePath: string): ParsedSession {
   let lastTimestamp: string | null = null;
   const messages: ParsedMessage[] = [];
   let codexFormat = false;
+  let assistantDisplayName = "Claude";
 
   for (const line of lines) {
     let parsed: RawRecord | CodexRecord;
@@ -165,6 +179,9 @@ export function parseSession(filePath: string): ParsedSession {
       }
 
       if (codexRecord.type === "session_meta") {
+        if (codexRecord.payload?.originator?.toLowerCase().includes("codex")) {
+          assistantDisplayName = "Codex";
+        }
         if (codexRecord.payload?.id) sessionId = codexRecord.payload.id;
         if (codexRecord.payload?.cwd && !projectPath) projectPath = codexRecord.payload.cwd;
         if (codexRecord.payload?.cli_version && !version) version = codexRecord.payload.cli_version;
@@ -244,12 +261,18 @@ export function parseSession(filePath: string): ParsedSession {
   }
 
   const projectName = projectNameFromPath(projectPath);
+  const userDisplayName = userDisplayNameFromPath(projectPath);
+  if (codexFormat && assistantDisplayName === "Claude") {
+    assistantDisplayName = "Codex";
+  }
 
   return {
     sessionId,
     parentSessionId,
     projectPath,
     projectName,
+    userDisplayName,
+    assistantDisplayName,
     gitBranch,
     version,
     startedAt: firstTimestamp || "",
@@ -268,7 +291,7 @@ export function parseSession(filePath: string): ParsedSession {
 
       for (const msg of messages) {
         const time = msg.timestamp.slice(0, 16).replace("T", " ");
-        const speaker = msg.role === "user" ? "User" : "Claude";
+        const speaker = msg.role === "user" ? userDisplayName : assistantDisplayName;
         const firstLine = msg.text.split("\n")[0];
         const truncated = msg.text.includes("\n")
           ? firstLine + " [...]"

--- a/src/web/views/conversation.test.ts
+++ b/src/web/views/conversation.test.ts
@@ -9,9 +9,9 @@ describe("renderConversation", () => {
 
   test("renders user message with outset label and inline timestamp", () => {
     const md = "**User (2026-02-21 17:37):** Fix the login bug";
-    const html = renderConversation(md);
+    const html = renderConversation(md, "peteror");
     expect(html).toContain("msg-label");
-    expect(html).toContain("Jesse");
+    expect(html).toContain("peteror");
     expect(html).toContain("msg-body-user");
     expect(html).toContain("Fix the login bug");
     expect(html).toContain("5:37 PM");
@@ -70,8 +70,24 @@ describe("renderConversation", () => {
       "**Human (2026-02-21 17:37):** First",
       "**Assistant (2026-02-21 17:37):** Second",
     ].join("\n");
-    const html = renderConversation(md);
-    expect(html).toContain("Jesse");
+    const html = renderConversation(md, "peteror");
+    expect(html).toContain("peteror");
     expect(html).toContain("Claude");
+  });
+
+  test("renders explicit user labels from markdown", () => {
+    const md = "**peteror (2026-02-21 17:37):** Hello";
+    const html = renderConversation(md);
+    expect(html).toContain("peteror");
+  });
+
+  test("can remap Claude/Assistant labels to Codex for legacy codex transcripts", () => {
+    const md = [
+      "**Claude (2026-02-21 17:37):** First",
+      "**Assistant (2026-02-21 17:38):** Second",
+    ].join("\n");
+    const html = renderConversation(md, "peteror", "Codex");
+    expect(html).toContain("Codex");
+    expect(html).not.toContain("msg-label\">Claude");
   });
 });

--- a/src/web/views/conversation.ts
+++ b/src/web/views/conversation.ts
@@ -1,7 +1,30 @@
 import { escapeHtml, formatTimeAmPm } from "./helpers";
 
 const MESSAGE_REGEX =
-  /^\*\*(User|Claude|Jesse|Assistant|Human)\s*\((?:\d{4}-\d{2}-\d{2}\s+)?(\d{2}:\d{2})\):\*\*\s*(.+)$/;
+  /^\*\*([^()]+?)\s*\((?:\d{4}-\d{2}-\d{2}\s+)?(\d{2}:\d{2})\):\*\*\s*(.+)$/;
+
+export function inferUserDisplayName(projectPath: string | null | undefined): string {
+  if (!projectPath) return "User";
+
+  const unixHomeMatch = projectPath.match(/^\/(?:Users|home)\/([^/]+)/);
+  if (unixHomeMatch?.[1]) return unixHomeMatch[1];
+
+  const windowsHomeMatch = projectPath.match(/^[A-Za-z]:\\Users\\([^\\]+)/);
+  if (windowsHomeMatch?.[1]) return windowsHomeMatch[1];
+
+  return "User";
+}
+
+export function inferAssistantDisplayName(sourcePath: string | null | undefined): string {
+  if (!sourcePath) return "Claude";
+  const normalized = sourcePath.replace(/\\/g, "/").toLowerCase();
+  return normalized.includes("/.codex/") ? "Codex" : "Claude";
+}
+
+function isAssistantSpeaker(speaker: string): boolean {
+  const normalized = speaker.trim().toLowerCase();
+  return normalized === "claude" || normalized === "assistant" || normalized === "codex";
+}
 
 type ParsedMessage = {
   speaker: string;
@@ -11,7 +34,11 @@ type ParsedMessage = {
   role: "user" | "claude";
 };
 
-function parseMessages(markdown: string): ParsedMessage[] {
+function parseMessages(
+  markdown: string,
+  userDisplayName: string,
+  assistantDisplayName: string
+): ParsedMessage[] {
   const lines = markdown.split("\n");
   const messages: ParsedMessage[] = [];
   let current: ParsedMessage | null = null;
@@ -20,12 +47,11 @@ function parseMessages(markdown: string): ParsedMessage[] {
     const match = line.match(MESSAGE_REGEX);
     if (match) {
       if (current) messages.push(current);
-      const speaker = match[1]!;
-      const role: "user" | "claude" =
-        speaker === "Claude" || speaker === "Assistant" ? "claude" : "user";
+      const speaker = match[1]!.trim();
+      const role: "user" | "claude" = isAssistantSpeaker(speaker) ? "claude" : "user";
       const displayName =
-        speaker === "User" || speaker === "Human" ? "Jesse" :
-        speaker === "Assistant" ? "Claude" : speaker;
+        speaker === "User" || speaker === "Human" ? userDisplayName :
+        isAssistantSpeaker(speaker) ? assistantDisplayName : speaker;
       current = {
         speaker,
         displayName,
@@ -63,12 +89,16 @@ function mergeConsecutive(messages: ParsedMessage[]): ParsedMessage[] {
   return merged;
 }
 
-export function renderConversation(markdown: string): string {
+export function renderConversation(
+  markdown: string,
+  userDisplayName = "User",
+  assistantDisplayName = "Claude"
+): string {
   if (!markdown || markdown.trim() === "") {
     return '<div class="empty-state">No conversation data.</div>';
   }
 
-  const messages = parseMessages(markdown);
+  const messages = parseMessages(markdown, userDisplayName, assistantDisplayName);
   if (messages.length === 0) {
     return `<div class="transcript"><pre style="white-space: pre-wrap; font-size: 13px;">${escapeHtml(markdown)}</pre></div>`;
   }

--- a/src/web/views/journal.ts
+++ b/src/web/views/journal.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { escapeHtml, formatDateShort, formatDate, formatTimeAmPm, formatTime, groupByTimeBucket } from "./helpers";
-import { renderConversation } from "./conversation";
+import { inferAssistantDisplayName, inferUserDisplayName, renderConversation } from "./conversation";
 import { renderSessionFooter } from "./session";
 
 type JournalEntryRow = {
@@ -168,7 +168,12 @@ export function renderEntryConversations(db: Database, entryId: number, sessionI
   const idx = Math.max(0, Math.min(sessionIndex, sessionIds.length - 1));
   const sessionId = sessionIds[idx]!;
 
-  const convo = db.query(`SELECT conversation_markdown FROM conversations WHERE session_id = ?`).get(sessionId) as { conversation_markdown: string } | null;
+  const convo = db.query(`
+    SELECT c.conversation_markdown, s.project_path, s.source_path
+    FROM conversations c
+    JOIN sessions s ON s.id = c.session_id
+    WHERE c.session_id = ?
+  `).get(sessionId) as { conversation_markdown: string; project_path: string; source_path: string } | null;
 
   let html = `<button class="panel-dismiss" onclick="this.parentElement.innerHTML='<div class=\\'empty-state\\'>Select an entry to view conversations.</div>'">&times;</button>`;
   // Session navigator
@@ -185,7 +190,11 @@ export function renderEntryConversations(db: Database, entryId: number, sessionI
   }
 
   if (convo) {
-    html += renderConversation(convo.conversation_markdown);
+    html += renderConversation(
+      convo.conversation_markdown,
+      inferUserDisplayName(convo.project_path),
+      inferAssistantDisplayName(convo.source_path)
+    );
   } else {
     html += '<div class="empty-state">Conversation not available.</div>';
   }

--- a/src/web/views/session.test.ts
+++ b/src/web/views/session.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from "bun:test";
+import { renderSessionFooter } from "./session";
+
+describe("renderSessionFooter", () => {
+  test("renders Claude resume command for Claude session source paths", () => {
+    const html = renderSessionFooter(
+      "abc-session-id",
+      "/Users/peteror/Code/engineering-notebook",
+      "/Users/peteror/.claude/projects/myproj/abc-session-id.jsonl"
+    );
+
+    expect(html).toContain("claude --resume abc-session-id");
+    expect(html).not.toContain("codex resume");
+  });
+
+  test("renders Codex resume command for Codex session source paths", () => {
+    const html = renderSessionFooter(
+      "019bf429-646d-70c2-a8b8-a0d69db3f01d",
+      "/Users/peteror/Code/engineering-notebook",
+      "/Users/peteror/.codex/sessions/2026/02/24/rollout-2026-02-24T09-00-00-019bf429-646d-70c2-a8b8-a0d69db3f01d.jsonl"
+    );
+
+    expect(html).toContain("codex resume 019bf429-646d-70c2-a8b8-a0d69db3f01d");
+    expect(html).not.toContain("claude --resume");
+  });
+});

--- a/src/web/views/session.ts
+++ b/src/web/views/session.ts
@@ -1,12 +1,15 @@
 import { Database } from "bun:sqlite";
-import { renderConversation } from "./conversation";
+import { inferAssistantDisplayName, inferUserDisplayName, renderConversation } from "./conversation";
 import { escapeHtml } from "./helpers";
 
 /**
  * Render a resume command footer with copy button and source path.
  */
 export function renderSessionFooter(sessionId: string, projectPath: string, sourcePath: string): string {
-  const resumeCmd = `cd ${projectPath} && claude --resume ${sessionId}`;
+  const isCodexSession = sourcePath.includes("/.codex/sessions/");
+  const resumeCmd = isCodexSession
+    ? `cd ${projectPath} && codex resume ${sessionId}`
+    : `cd ${projectPath} && claude --resume ${sessionId}`;
   let html = `<div class="session-footer">`;
   html += `<div class="session-footer-resume">`;
   html += `<code>${escapeHtml(resumeCmd)}</code>`;
@@ -47,7 +50,11 @@ export function renderSessionDetail(db: Database, sessionId: string): string {
   html += `</div></div>`;
 
   if (session.conversation_markdown) {
-    html += renderConversation(session.conversation_markdown);
+    html += renderConversation(
+      session.conversation_markdown,
+      inferUserDisplayName(session.project_path),
+      inferAssistantDisplayName(session.source_path)
+    );
   } else {
     html += '<div class="empty-state">No conversation data.</div>';
   }


### PR DESCRIPTION
## Summary
Replaced hardcoded transcript speaker names (`Jesse` and always-`Claude`) with display names from the sessions for both user and assistant messages. Added the correct command for session resume for Codex

## What Changed
- Added user display-name inference from `projectPath`:
- `/Users/<name>/...`
- `/home/<name>/...`
- `C:\Users\<name>\...`
- Default fallback: `User`.

- Added assistant display-name support in parsing:
- Codex sessions now set `assistantDisplayName` to `Codex` (using session format/originator detection).
- Claude sessions remain `Claude`.

- Updated markdown generation:
- Parsed conversation markdown now emits inferred user name and inferred assistant name instead of fixed labels.

- Updated renderer behavior:
- Removed hardcoded username.
- Generalized message parsing to accept arbitrary user / agent labels.
- Added optional assistant remapping for legacy transcripts:
- If session source path indicates `.codex`, `Claude/Assistant` display as `Codex`.
- Otherwise they display as `Claude`.
- Wired session metadata into journal/session transcript rendering so the renderer can infer correct user/assistant labels for already-ingested data.

## Tests
- Updated parser tests for:
- `userDisplayName`
- `assistantDisplayName`
- Codex markdown assistant label

- Updated conversation rendering tests for:
- Dynamic user label mapping
- Legacy Claude/Assistant remapping to Codex
- Arbitrary explicit speaker label support

- Ran:
- `bun test src/parser.test.ts src/web/views/conversation.test.ts`
- Result: `21 pass, 0 fail`

## Notes
- Existing stored transcripts should now render with correct names in most cases via metadata inference.
- Re-ingesting sessions will persist the improved display names directly in conversation markdown.