### PR TITLE
Add pre-commit hooks for tests and typechecking

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+echo ">> bun test"
+bun test
+
+echo ">> typecheck"
+bun run typecheck
+
+echo "All checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
           bun-version: latest
 
       - run: bun install --frozen-lockfile
-      - run: bunx tsc --noEmit
+      - run: bun --bun node_modules/.bin/tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "bin": {
     "engineering-notebook": "src/index.ts"
   },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "bun --bun node_modules/.bin/tsc --noEmit",
+    "check": "bun test && bun run typecheck",
+    "prepare": "git config core.hooksPath .githooks"
+  },
   "devDependencies": {
     "@types/bun": "^1.3.9"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ switch (command) {
     const sources = config.sources.map(expandPath);
     const sourceIdx = process.argv.indexOf("--source");
     if (sourceIdx !== -1 && process.argv[sourceIdx + 1]) {
-      sources.push(expandPath(process.argv[sourceIdx + 1]));
+      sources.push(expandPath(process.argv[sourceIdx + 1]!));
     }
 
     // Sync remote sources
@@ -102,7 +102,7 @@ switch (command) {
 
     const port = (() => {
       const portIdx = process.argv.indexOf("--port");
-      return portIdx !== -1 ? parseInt(process.argv[portIdx + 1]) : config.port;
+      return portIdx !== -1 ? parseInt(process.argv[portIdx + 1]!) : config.port;
     })();
 
     console.log(`Engineering Notebook running at http://localhost:${port}`);

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -27,8 +27,8 @@ describe("parseSession", () => {
     const session = parseSession(fixturePath);
     const userMessages = session.messages.filter((m) => m.role === "user");
     expect(userMessages.length).toBe(2);
-    expect(userMessages[0].text).toBe("Fix the login bug");
-    expect(userMessages[1].text).toBe("Great, fix it please");
+    expect(userMessages[0]!.text).toBe("Fix the login bug");
+    expect(userMessages[1]!.text).toBe("Great, fix it please");
   });
 
   test("skips thinking blocks from assistant", () => {

--- a/src/summarize.test.ts
+++ b/src/summarize.test.ts
@@ -38,15 +38,15 @@ describe("summarize", () => {
   test("groupSessionsByDateAndProject groups correctly", () => {
     const groups = groupSessionsByDateAndProject(db);
     expect(groups.length).toBe(1);
-    expect(groups[0].date).toBe("2026-02-02");
-    expect(groups[0].projectId).toBe("myapp");
-    expect(groups[0].sessionIds).toEqual(["s1", "s2"]);
-    expect(groups[0].conversations.length).toBe(2);
+    expect(groups[0]!.date).toBe("2026-02-02");
+    expect(groups[0]!.projectId).toBe("myapp");
+    expect(groups[0]!.sessionIds).toEqual(["s1", "s2"]);
+    expect(groups[0]!.conversations.length).toBe(2);
   });
 
   test("buildSummaryPrompt produces valid prompt", () => {
     const groups = groupSessionsByDateAndProject(db);
-    const prompt = buildSummaryPrompt(groups[0]);
+    const prompt = buildSummaryPrompt(groups[0]!);
     expect(prompt).toContain("Fix the bug");
     expect(prompt).toContain("Add tests");
     expect(prompt).toContain("engineering journal entry");
@@ -223,17 +223,17 @@ describe("groupSessionsByDateAndProject - midnight spanning", () => {
     const sorted = groups.sort((a, b) => a.date.localeCompare(b.date));
 
     // Feb 20: messages at 22:00, 22:10, 01:30, 01:35 (all logical date Feb 20)
-    expect(sorted[0].date).toBe("2026-02-20");
-    expect(sorted[0].projectId).toBe("myapp");
-    expect(sorted[0].sessionIds).toEqual(["s-midnight"]);
-    expect(sorted[0].conversations[0]).toContain("Late night refactor");
-    expect(sorted[0].conversations[0]).toContain("Still at it");
+    expect(sorted[0]!.date).toBe("2026-02-20");
+    expect(sorted[0]!.projectId).toBe("myapp");
+    expect(sorted[0]!.sessionIds).toEqual(["s-midnight"]);
+    expect(sorted[0]!.conversations[0]).toContain("Late night refactor");
+    expect(sorted[0]!.conversations[0]).toContain("Still at it");
 
     // Feb 21: messages at 06:00, 06:05 (logical date Feb 21)
-    expect(sorted[1].date).toBe("2026-02-21");
-    expect(sorted[1].projectId).toBe("myapp");
-    expect(sorted[1].sessionIds).toEqual(["s-midnight"]);
-    expect(sorted[1].conversations[0]).toContain("Morning review");
+    expect(sorted[1]!.date).toBe("2026-02-21");
+    expect(sorted[1]!.projectId).toBe("myapp");
+    expect(sorted[1]!.sessionIds).toEqual(["s-midnight"]);
+    expect(sorted[1]!.conversations[0]).toContain("Morning review");
   });
 
   test("filters out already-summarized date+project combos", () => {
@@ -246,13 +246,13 @@ describe("groupSessionsByDateAndProject - midnight spanning", () => {
     const groups = groupSessionsByDateAndProject(db);
     // Only Feb 21 should remain
     expect(groups.length).toBe(1);
-    expect(groups[0].date).toBe("2026-02-21");
+    expect(groups[0]!.date).toBe("2026-02-21");
   });
 
   test("filterDate works with logical dates", () => {
     const groups = groupSessionsByDateAndProject(db, "2026-02-21");
     expect(groups.length).toBe(1);
-    expect(groups[0].date).toBe("2026-02-21");
-    expect(groups[0].conversations[0]).toContain("Morning review");
+    expect(groups[0]!.date).toBe("2026-02-21");
+    expect(groups[0]!.conversations[0]).toContain("Morning review");
   });
 });

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -19,8 +19,8 @@ async function getClaudeAuthIssue(): Promise<string | null> {
   }
 
   const [stdout, stderr, exitCode] = await Promise.all([
-    readStream(proc.stdout),
-    readStream(proc.stderr),
+    readStream(proc.stdout as ReadableStream<Uint8Array> | null),
+    readStream(proc.stderr as ReadableStream<Uint8Array> | null),
     proc.exited,
   ]);
 
@@ -105,7 +105,7 @@ export function splitConversationByDay(
     );
     if (match) {
       foundAny = true;
-      currentDay = logicalDate(match[1], dayStartHour);
+      currentDay = logicalDate(match[1]!, dayStartHour);
       if (!byDay.has(currentDay)) byDay.set(currentDay, []);
       byDay.get(currentDay)!.push(line);
     } else if (currentDay) {
@@ -290,7 +290,7 @@ export function parseSummaryResponse(response: string): SummaryResult {
   const trimmed = response.trim();
   const skipMatch = trimmed.match(/^SKIP:\s*(.+)/);
   if (skipMatch) {
-    return { skipped: true, skipReason: skipMatch[1].trim() };
+    return { skipped: true, skipReason: skipMatch[1]!.trim() };
   }
 
   const headlineMatch = response.match(
@@ -306,13 +306,13 @@ export function parseSummaryResponse(response: string): SummaryResult {
     /OPEN_QUESTIONS:\s*([\s\S]*?)$/
   );
 
-  const headline = headlineMatch ? headlineMatch[1].trim() : "";
-  const summary = summaryMatch ? summaryMatch[1].trim() : response.trim();
+  const headline = headlineMatch ? headlineMatch[1]!.trim() : "";
+  const summary = summaryMatch ? summaryMatch[1]!.trim() : response.trim();
 
   let topics: string[] = [];
   if (topicsSection) {
     try {
-      topics = JSON.parse(topicsSection[1].trim());
+      topics = JSON.parse(topicsSection[1]!.trim());
     } catch {
       topics = [];
     }
@@ -321,7 +321,7 @@ export function parseSummaryResponse(response: string): SummaryResult {
   let openQuestions: string[] = [];
   if (openQuestionsSection) {
     try {
-      openQuestions = JSON.parse(openQuestionsSection[1].trim());
+      openQuestions = JSON.parse(openQuestionsSection[1]!.trim());
     } catch {
       openQuestions = [];
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -216,7 +216,7 @@ export class SyncManager {
       this.db, date, projectId, this.config.day_start_hour
     );
     if (groups.length === 0) return null;
-    const result = await summarizeGroup(groups[0], this.db);
+    const result = await summarizeGroup(groups[0]!, this.db);
     if (result.skipped) return null;
     const row = this.db.query(
       `SELECT id FROM journal_entries WHERE project_id = ? AND date = ?`

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -90,10 +90,10 @@ describe("server", () => {
       expect(res.status).toBe(302);
       const saved = loadConfig(configPath);
       expect(saved.remote_sources).toHaveLength(2);
-      expect(saved.remote_sources[0].name).toBe("Work MacBook");
-      expect(saved.remote_sources[0].host).toBe("jesse@macbook.local");
-      expect(saved.remote_sources[1].name).toBe("Home Desktop");
-      expect(saved.remote_sources[1].path).toBe("/data/claude/projects");
+      expect(saved.remote_sources[0]!.name).toBe("Work MacBook");
+      expect(saved.remote_sources[0]!.host).toBe("jesse@macbook.local");
+      expect(saved.remote_sources[1]!.name).toBe("Home Desktop");
+      expect(saved.remote_sources[1]!.path).toBe("/data/claude/projects");
     });
 
     test("saves remote sources with sequential indices", async () => {
@@ -116,8 +116,8 @@ describe("server", () => {
       expect(res.status).toBe(302);
       const saved = loadConfig(configPath);
       expect(saved.remote_sources).toHaveLength(2);
-      expect(saved.remote_sources[0].enabled).toBe(true);
-      expect(saved.remote_sources[1].enabled).toBe(false);
+      expect(saved.remote_sources[0]!.enabled).toBe(true);
+      expect(saved.remote_sources[1]!.enabled).toBe(false);
     });
 
     test("saves mix of sequential and timestamp indices", async () => {


### PR DESCRIPTION
## Summary
- Adds a version-controlled `.githooks/pre-commit` hook that runs `bun test` and `tsc --noEmit` before every commit, blocking commits that break tests or types
- Adds `test`, `typecheck`, `check`, and `prepare` scripts to `package.json` — the `prepare` script auto-activates the hooks directory on `bun install`
- Fixes 30+ pre-existing `noUncheckedIndexedAccess` TypeScript errors across 6 files so the typecheck gate passes cleanly
- Updates CI to use `bun --bun` tsc invocation for consistency with local development

## Test plan
- [x] `bun test` — 80 tests pass
- [x] `bun run typecheck` — clean, no errors
- [x] `bun run check` — both pass together
- [x] Pre-commit hook fires and passes on its own commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)