### PR TITLE
fix: align transcript speaker labels with message text

### DIFF
--- a/src/web/views/layout.ts
+++ b/src/web/views/layout.ts
@@ -320,7 +320,7 @@ export function renderLayout(title: string, content: LayoutContent): string {
       position: relative;
     }
     .msg { margin-bottom: 10px; position: relative; }
-    .msg-speaker-change { padding-top: 10px; border-top: 1px solid var(--border-subtle); }
+    .msg-speaker-change { margin-top: 10px; border-top: 1px solid var(--border-subtle); }
     .msg-label {
       position: absolute;
       left: -84px;


### PR DESCRIPTION
## Summary

- `padding-top` on `.msg-speaker-change` was pushing message text down by 10px while the absolutely-positioned `.msg-label` stayed pinned at `top: 0`, causing speaker names to appear misaligned with the first line of their messages
- Switching to `margin-top` moves the whole block down together, keeping the label and text baseline aligned

## Test plan

- [ ] Open a conversation transcript with multiple speaker changes and verify names align with the first line of each message

🤖 Generated with [Claude Code](https://claude.com/claude-code)