### PR TITLE
feat: detailed ingest output with skip reasons, progress bar, and totals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,15 +37,54 @@ switch (command) {
       }
     }
 
+    const startMs = Date.now();
     console.log(`Scanning ${sources.length} source(s)...`);
-    const files = scanSources(sources, config.exclude);
-    console.log(`Found ${files.length} session file(s)`);
+    const files: string[] = [];
+    for (const s of sources) {
+      const found = scanSources([s], config.exclude);
+      files.push(...found);
+      console.log(`  ${found.length.toLocaleString()} in ${s}`);
+    }
+    console.log(`Found ${files.length.toLocaleString()} session file(s)`);
 
-    const result = ingestSessions(files, db, force);
+    const isTty = process.stderr.isTTY;
+    const barWidth = Math.max(20, Math.min(40, (process.stdout.columns ?? 80) - 30));
+    const renderBar = (done: number, total: number): string => {
+      const partials = "▏▎▍▌▋▊▉";
+      const ratio = total > 0 ? Math.min(1, done / total) : 1;
+      const eighths = Math.round(ratio * barWidth * 8);
+      const full = Math.floor(eighths / 8);
+      const partial = eighths % 8;
+      const partialChar = partial > 0 && full < barWidth ? partials[partial - 1]! : "";
+      const empty = Math.max(0, barWidth - full - (partialChar ? 1 : 0));
+      return "█".repeat(full) + partialChar + " ".repeat(empty);
+    };
+    let lastTickMs = 0;
+    const result = ingestSessions(files, db, force, (done, total) => {
+      if (!isTty) return;
+      const now = Date.now();
+      if (now - lastTickMs < 100 && done < total) return;
+      lastTickMs = now;
+      const pct = total > 0 ? Math.floor((done / total) * 100) : 100;
+      process.stderr.write(
+        `\r\x1b[2K  [${renderBar(done, total)}] ${pct.toString().padStart(3)}% · ${done.toLocaleString()}/${total.toLocaleString()}`
+      );
+    });
+    if (isTty) process.stderr.write("\r\x1b[2K");
+
+    const elapsed = ((Date.now() - startMs) / 1000).toFixed(1);
     console.log(
-      `Ingested: ${result.ingested}, Skipped: ${result.skipped}, Errors: ${result.errors.length}`
+      `Ingested ${result.ingested.toLocaleString()} session(s) (${result.totalMessages.toLocaleString()} messages) in ${elapsed}s`
     );
+    if (result.skipped > 0) {
+      const parts: string[] = [];
+      if (result.alreadyIngested) parts.push(`${result.alreadyIngested.toLocaleString()} already ingested`);
+      if (result.empty) parts.push(`${result.empty.toLocaleString()} empty`);
+      if (result.duplicateId) parts.push(`${result.duplicateId.toLocaleString()} duplicate id`);
+      console.log(`Skipped ${result.skipped.toLocaleString()}: ${parts.join(", ")}`);
+    }
     if (result.errors.length > 0) {
+      console.log(`Errors: ${result.errors.length}`);
       for (const err of result.errors.slice(0, 10)) {
         console.error(`  ${err}`);
       }

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -60,10 +60,13 @@ export function scanSources(
 export function ingestSessions(
   files: string[],
   db: Database,
-  force = false
-): { ingested: number; skipped: number; errors: string[] } {
-  let ingested = 0;
-  let skipped = 0;
+  force = false,
+  onProgress?: (done: number, total: number) => void
+): {
+  ingested: number; skipped: number; errors: string[];
+  alreadyIngested: number; empty: number; duplicateId: number; totalMessages: number;
+} {
+  let ingested = 0, alreadyIngested = 0, empty = 0, duplicateId = 0, totalMessages = 0;
   const errors: string[] = [];
 
   const checkStmt = db.query("SELECT id FROM sessions WHERE source_path = ?");
@@ -84,30 +87,27 @@ export function ingestSessions(
   const deleteConvo = db.prepare(`DELETE FROM conversations WHERE session_id = ?`);
   const deleteSession = db.prepare(`DELETE FROM sessions WHERE id = ?`);
 
-  for (const file of files) {
-    if (!force) {
-      const existing = checkStmt.get(file);
-      if (existing) {
-        skipped++;
-        continue;
-      }
+  for (let i = 0; i < files.length; i++) {
+    onProgress?.(i, files.length);
+    const file = files[i]!;
+
+    if (!force && checkStmt.get(file)) {
+      alreadyIngested++;
+      continue;
     }
 
     try {
       const session = parseSession(file);
 
       if (session.messageCount === 0) {
-        skipped++;
+        empty++;
         continue;
       }
 
       // Skip if session ID already exists (e.g., same session in multiple project dirs)
-      if (!force) {
-        const existingById = checkSessionId.get(session.sessionId);
-        if (existingById) {
-          skipped++;
-          continue;
-        }
+      if (!force && checkSessionId.get(session.sessionId)) {
+        duplicateId++;
+        continue;
       }
 
       const projectId = session.projectName;
@@ -140,10 +140,12 @@ export function ingestSessions(
       })();
 
       ingested++;
+      totalMessages += session.messageCount;
     } catch (err) {
       errors.push(`${file}: ${err}`);
     }
   }
+  onProgress?.(files.length, files.length);
 
   // Update project aggregate fields
   db.exec(`
@@ -153,5 +155,8 @@ export function ingestSessions(
       session_count = (SELECT COUNT(*) FROM sessions WHERE sessions.project_id = projects.id)
   `);
 
-  return { ingested, skipped, errors };
+  return {
+    ingested, skipped: alreadyIngested + empty + duplicateId, errors,
+    alreadyIngested, empty, duplicateId, totalMessages,
+  };
 }


### PR DESCRIPTION
## Summary

Replaces the three-line summary at the end of `engineering-notebook ingest` with a richer, scannable report. Same command, no flags, no behavior changes — only the output is different.

**Before:**
```
Scanning 2 source(s)...
Found 4650 session file(s)
Ingested: 4313, Skipped: 337, Errors: 0
```

**After:**
```
Scanning 2 source(s)...
  4,294 in /Users/me/.claude/projects
    356 in /Users/me/.codex/sessions
Found 4,650 session file(s)
  [████████████████████] 100% · 4,650/4,650
Ingested 4,313 session(s) (812,540 messages) in 47.2s
Skipped 337: 337 empty
```

## What changed

- **Per-source file counts** during the scan phase — easy to spot when a source dir is empty or surprisingly small.
- **Skip-reason breakdown** — the single `skipped` counter is now split into `already_ingested` / `empty` / `duplicate_id`. The aggregate `skipped` field is preserved on the return object so existing tests still pass. Turns an opaque number into something you can act on (e.g. *"all 337 skipped were `empty` sessions, not duplicates"*).
- **Total messages ingested** + **elapsed time**.
- **Live progress bar** (TTY-only, 100ms throttle, sub-character eighth-block fill for smooth progression) — handcrafted in ~10 lines, no new dependency.

## Implementation notes

- `ingestSessions` gains an optional 4th argument `onProgress?: (done, total) => void`. Default omitted → existing call sites unchanged.
- Counters that previously fed `skipped++` now feed individual reasons; the returned `skipped` is computed as their sum so `ingest.test.ts` keeps passing without modification.
- Progress writer gates on `process.stderr.isTTY` so piped output (CI, `>file`) stays clean.
- Bar width adapts to `process.stdout.columns`, clamped to 20–40 chars.

## Test plan

- [x] `bun test` — all 92 tests pass (no test changes needed; existing `ingest.test.ts` exercises the preserved `ingested` / `skipped` / `errors` fields)
- [x] `bun run typecheck` clean
- [x] Pre-commit hooks green
- [x] Manually verified bar rendering at 0/5/12/25/37/50/67/87/99/100% — sub-char partials engage at non-multiples of 5%, no off-by-one width drift
- [x] Manually ran `bun src/index.ts ingest` against a 4,650-file dataset and confirmed the new output