### PR TITLE
Add Cursor session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Engineering Notebook
 
-A CLI tool that ingests [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://openai.com/index/introducing-codex/) session transcripts, generates LLM-powered daily summaries, and serves a web UI for browsing your engineering journal.
+A CLI tool that ingests [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://openai.com/index/introducing-codex/), and [Cursor](https://cursor.com) session transcripts, generates LLM-powered daily summaries, and serves a web UI for browsing your engineering journal.
 
 Think of it as an automatic engineering diary — it watches your AI coding sessions and distills them into a searchable, browsable narrative of what you built, what problems you hit, and what decisions you made.
 
@@ -8,7 +8,7 @@ Think of it as an automatic engineering diary — it watches your AI coding sess
 
 ## How It Works
 
-1. **Ingest** — Scans directories of Claude Code and Codex JSONL session files, parses out the human-readable conversation (stripping tool calls, thinking blocks, etc.), and stores them in SQLite.
+1. **Ingest** — Scans directories of Claude Code, Codex, and Cursor JSONL session files, parses out the human-readable conversation (stripping tool calls, thinking blocks, etc.), and stores them in SQLite.
 2. **Summarize** — Groups sessions by date and project, then uses Claude to write concise engineering journal entries with headlines, summaries, topics, and open questions.
 3. **Serve** — Runs a web server with a browsable UI: daily journal, project timelines, calendar/Gantt view, session transcripts, full-text search, and an iCal feed.
 
@@ -141,6 +141,37 @@ webcal://localhost:3000/api/calendar.ics
 ```
 
 This creates calendar events for each journal entry, viewable in Apple Calendar, Google Calendar, Outlook, etc.
+
+## Cursor support
+
+Cursor sessions live under `~/.cursor/projects` (Cursor's `agent-transcripts/`
+layout). This source is **not** scanned by default — add it explicitly:
+
+```sh
+engineering-notebook ingest --source ~/.cursor/projects
+```
+
+Or add `~/.cursor/projects` to the `sources` array in your config.
+
+Cursor's transcript format is leaner than Claude Code's or Codex's, so a few
+caveats apply:
+
+- **Timestamps come from file modification times.** Cursor transcripts contain no
+  per-message timestamps, so a session's start and end are taken from the file's
+  creation and last-modified times, and per-message times are approximate. Copying
+  or restoring transcript files can reset these.
+- **Project names are the raw encoded directory string** (for example
+  `Users-username-GitRepos-my-repo`). Cursor does not record the working directory,
+  and its directory names encode the path lossily — both `/` and `.` collapse to
+  `-` — so the name is shown verbatim rather than guessed at.
+- **Cursor sessions do not auto-merge** with the same repository's Claude Code or
+  Codex sessions, which group by the real working-directory name.
+- **Some Cursor projects appear under an opaque numeric id** (for example
+  `1700000000000`) when Cursor stored no recoverable path.
+
+Planned improvements (not yet implemented): stripping `<attached_files>` and
+terminal-selection wrappers from Cursor messages, and recovering real project
+names via Cursor's `workspaceStorage` mapping.
 
 ## Development
 

--- a/src/ingest.test.ts
+++ b/src/ingest.test.ts
@@ -170,4 +170,34 @@ describe("ingestSessions", () => {
     expect(session?.version).toBe("0.99.0-alpha.23");
     expect(session?.message_count).toBe(2);
   });
+
+  test("ingests a Cursor session file into the database", () => {
+    const uuid = "11111111-1111-4111-8111-111111111111";
+    const fixturePath = join(
+      import.meta.dir,
+      `../tests/fixtures/cursor/Users-test-GitRepos-demo-app/agent-transcripts/${uuid}/${uuid}.jsonl`
+    );
+    const dir = join(tempDir, "Users-test-GitRepos-demo-app", "agent-transcripts", uuid);
+    mkdirSync(dir, { recursive: true });
+    const sessionFile = join(dir, `${uuid}.jsonl`);
+    copyFileSync(fixturePath, sessionFile);
+
+    const result = ingestSessions([sessionFile], db);
+    expect(result.ingested).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.errors.length).toBe(0);
+
+    const session = db
+      .query("SELECT id, project_id, message_count, is_subagent FROM sessions")
+      .get() as {
+      id: string;
+      project_id: string;
+      message_count: number;
+      is_subagent: number;
+    } | null;
+    expect(session?.id).toBe(uuid);
+    expect(session?.project_id).toBe("Users-test-GitRepos-demo-app");
+    expect(session?.message_count).toBe(3);
+    expect(session?.is_subagent).toBe(0);
+  });
 });

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -6,6 +6,14 @@ const fixturePath = join(import.meta.dir, "../tests/fixtures/test-session-1.json
 const codexFixturePath = join(import.meta.dir, "../tests/fixtures/test-codex-session-1.jsonl");
 const subagentFixturePath = join(import.meta.dir, "../tests/fixtures/parent-session-id/subagents/agent-aba4e4e.jsonl");
 const commandFixturePath = join(import.meta.dir, "../tests/fixtures/test-command-messages.jsonl");
+const cursorFixturePath = join(
+  import.meta.dir,
+  "../tests/fixtures/cursor/Users-test-GitRepos-demo-app/agent-transcripts/11111111-1111-4111-8111-111111111111/11111111-1111-4111-8111-111111111111.jsonl"
+);
+const cursorEpochFixturePath = join(
+  import.meta.dir,
+  "../tests/fixtures/cursor/1700000000000/agent-transcripts/22222222-2222-4222-8222-222222222222/22222222-2222-4222-8222-222222222222.jsonl"
+);
 
 describe("parseSession", () => {
   test("extracts session metadata", () => {
@@ -125,5 +133,51 @@ describe("parseSession", () => {
     expect(userMessages.length).toBe(2);
     expect(userMessages[0]!.text).toBe("/brainstorm fix the login bug");
     expect(userMessages[1]!.text).toBe("/commit");
+  });
+
+  test("parses Cursor records (role + message, no type)", () => {
+    const session = parseSession(cursorFixturePath);
+    expect(session.messages.length).toBe(3);
+    expect(session.messageCount).toBe(3);
+    expect(session.messages[0]!.role).toBe("user");
+    expect(session.messages[0]!.text).toBe("Add a health check endpoint");
+    expect(session.messages[1]!.role).toBe("assistant");
+    expect(session.messages[2]!.role).toBe("assistant");
+  });
+
+  test("joins multiple Cursor text blocks in one message", () => {
+    const session = parseSession(cursorFixturePath);
+    expect(session.messages[1]!.text).toBe("Sure,\nI'll add a /health route.");
+  });
+
+  test("uses filename UUID as Cursor session id", () => {
+    const session = parseSession(cursorFixturePath);
+    expect(session.sessionId).toBe("11111111-1111-4111-8111-111111111111");
+  });
+
+  test("uses full encoded directory as Cursor project name", () => {
+    const session = parseSession(cursorFixturePath);
+    expect(session.projectName).toBe("Users-test-GitRepos-demo-app");
+    expect(session.assistantDisplayName).toBe("Cursor");
+  });
+
+  test("uses raw epoch id as Cursor project name for opaque dirs", () => {
+    const session = parseSession(cursorEpochFixturePath);
+    expect(session.projectName).toBe("1700000000000");
+  });
+
+  test("derives Cursor timestamps from file times", () => {
+    const session = parseSession(cursorFixturePath);
+    expect(session.startedAt).toBeTruthy();
+    expect(session.endedAt).toBeTruthy();
+    expect(session.startedAt <= session.endedAt!).toBe(true);
+  });
+
+  test("uses Cursor label in markdown", () => {
+    const session = parseSession(cursorFixturePath);
+    const md = session.toMarkdown();
+    expect(md).toContain("# Session: Users-test-GitRepos-demo-app");
+    expect(md).toContain("**Cursor (");
+    expect(md).toContain("Done. Added GET /health returning 200.");
   });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync, statSync } from "fs";
 import { basename } from "path";
 
 export type MessageRole = "user" | "assistant";
@@ -61,6 +61,13 @@ type CodexRecord = {
   };
 };
 
+type CursorRecord = {
+  role?: string;
+  message?: {
+    content: string | ContentBlock[];
+  };
+};
+
 type ContentBlock = {
   type: string;
   text?: string;
@@ -83,6 +90,17 @@ function userDisplayNameFromPath(projectPath: string): string {
   if (windowsHomeMatch?.[1]) return windowsHomeMatch[1];
 
   return "User";
+}
+
+/** Cursor stores no cwd. Derive the project from the encoded directory name
+ *  that sits immediately before `agent-transcripts/` in the file path. The name
+ *  is the raw dash-encoded string and is intentionally NOT decoded — the
+ *  encoding is lossy (both `/` and `.` collapse to `-`). See README caveats. */
+function cursorProjectFromPath(filePath: string): string {
+  const parts = filePath.split("/").filter(Boolean);
+  const idx = parts.indexOf("agent-transcripts");
+  if (idx > 0) return parts[idx - 1]!;
+  return parts.length >= 2 ? parts[parts.length - 2]! : "cursor";
 }
 
 /** Format a UTC ISO timestamp to HH:MM using UTC hours/minutes */
@@ -172,6 +190,7 @@ export function parseSession(filePath: string): ParsedSession {
   let lastTimestamp: string | null = null;
   const messages: ParsedMessage[] = [];
   let codexFormat = false;
+  let cursorFormat = false;
   let assistantDisplayName = "Claude";
 
   for (const line of lines) {
@@ -225,6 +244,25 @@ export function parseSession(filePath: string): ParsedSession {
 
     const record = parsed as RawRecord;
 
+    // Cursor format: a top-level `role` with a `message`, and no `type` field.
+    // Content blocks share Claude's shape, so reuse the existing extractors.
+    // Project and timestamps are derived after the loop (Cursor records carry
+    // neither).
+    if (!record.type && record.message) {
+      const cursor = parsed as CursorRecord;
+      if (cursor.role === "user" || cursor.role === "assistant") {
+        cursorFormat = true;
+        const text =
+          cursor.role === "user"
+            ? extractUserText(record.message.content)
+            : extractAssistantText(record.message.content);
+        if (text) {
+          messages.push({ role: cursor.role, text, timestamp: "" });
+        }
+        continue;
+      }
+    }
+
     // Track the first sessionId we see to detect continuations.
     // Subagent files (path contains /subagents/) always have the parent's
     // sessionId in every record — this is expected, not a continuation.
@@ -276,10 +314,27 @@ export function parseSession(filePath: string): ParsedSession {
     }
   }
 
-  const projectName = projectNameFromPath(projectPath);
-  const userDisplayName = userDisplayNameFromPath(projectPath);
+  let projectName = projectNameFromPath(projectPath);
+  let userDisplayName = userDisplayNameFromPath(projectPath);
   if (codexFormat && assistantDisplayName === "Claude") {
     assistantDisplayName = "Codex";
+  }
+
+  if (cursorFormat) {
+    assistantDisplayName = "Cursor";
+    const dir = cursorProjectFromPath(filePath);
+    projectName = dir;
+    projectPath = dir;
+    userDisplayName = "User";
+
+    // Cursor transcripts have no timestamps; fall back to file times.
+    const stat = statSync(filePath);
+    const birth = stat.birthtime.getTime() ? stat.birthtime : stat.mtime;
+    firstTimestamp = birth.toISOString();
+    lastTimestamp = stat.mtime.toISOString();
+    for (const msg of messages) {
+      msg.timestamp = firstTimestamp;
+    }
   }
 
   return {

--- a/tests/fixtures/cursor/1700000000000/agent-transcripts/22222222-2222-4222-8222-222222222222/22222222-2222-4222-8222-222222222222.jsonl
+++ b/tests/fixtures/cursor/1700000000000/agent-transcripts/22222222-2222-4222-8222-222222222222/22222222-2222-4222-8222-222222222222.jsonl
@@ -1,0 +1,1 @@
+{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}

--- a/tests/fixtures/cursor/Users-test-GitRepos-demo-app/agent-transcripts/11111111-1111-4111-8111-111111111111/11111111-1111-4111-8111-111111111111.jsonl
+++ b/tests/fixtures/cursor/Users-test-GitRepos-demo-app/agent-transcripts/11111111-1111-4111-8111-111111111111/11111111-1111-4111-8111-111111111111.jsonl
@@ -1,0 +1,3 @@
+{"role":"user","message":{"content":[{"type":"text","text":"Add a health check endpoint"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Sure,"},{"type":"text","text":"I'll add a /health route."}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"Done. Added GET /health returning 200."}]}}


### PR DESCRIPTION
Closes #17.

Adds support for ingesting Cursor session transcripts. Cursor records are `{role, message}` with no `type` field, and content blocks share Claude Code's `{type:"text", text}` shape, so the existing text extractors are reused.

Metadata absent from Cursor transcripts is derived after parsing: session id from the filename UUID, start/end timestamps from file `birthtime`/`mtime` (Cursor stores none), and project name from Cursor's encoded directory string (used verbatim).

`~/.cursor/projects` is **not** added to default sources — it stays opt-in and is documented, along with the format's caveats (file-derived timestamps, raw encoded project names that won't auto-merge with Claude/Codex sessions, opaque numeric-id project dirs).

## Tests
- New parser tests: format detection, multi-block join, session id, project name (including opaque epoch-id dirs), file-time fallback, markdown label.
- New ingest regression test.
- `bun test && bun run typecheck` pass.