### PR TITLE
Regenerate a journal entry when its date is named explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ Generate LLM summaries for ingested sessions.
 
 ```sh
 engineering-notebook summarize --all                      # summarize everything unsummarized
-engineering-notebook summarize --date 2026-02-22          # summarize a specific date
+engineering-notebook summarize --date 2026-02-22          # summarize (or re-summarize) a date
 engineering-notebook summarize --project myapp            # summarize a specific project
 engineering-notebook summarize --date 2026-02-22 --project myapp  # both filters
 ```
+
+`--all` only visits dates that have no entry yet, so re-running it never rewrites
+existing entries. Naming a date with `--date` **does** regenerate it, replacing
+whatever is there. That is what you want for the current day: a day gets
+summarized while you are still working, and re-running `--date today` folds in
+everything since. Pair it with `--project` to regenerate a single project's entry.
 
 ### `engineering-notebook serve`
 

--- a/src/summarize.test.ts
+++ b/src/summarize.test.ts
@@ -256,3 +256,48 @@ describe("groupSessionsByDateAndProject - midnight spanning", () => {
     expect(groups[0]!.conversations[0]).toContain("Morning review");
   });
 });
+
+describe("re-summarizing an explicitly named date", () => {
+  let tempDir: string;
+  let db: ReturnType<typeof initDb>;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "notebook-resummarize-"));
+    db = initDb(join(tempDir, "test.db"));
+
+    db.exec(`
+      INSERT INTO projects (id, path, display_name, session_count)
+      VALUES ('myapp', '/test/myapp', 'My App', 1);
+
+      INSERT INTO sessions (id, project_id, project_path, source_path, started_at, ended_at, message_count, ingested_at)
+      VALUES ('s-1', 'myapp', '/test/myapp', '/tmp/s1.jsonl', '2026-02-20T10:00:00Z', '2026-02-20T11:00:00Z', 2, datetime('now'));
+
+      INSERT INTO conversations (session_id, conversation_markdown, extracted_at)
+      VALUES ('s-1', '**User (2026-02-20 10:00):** Do the thing\n**Claude (2026-02-20 10:05):** Done.', datetime('now'));
+
+      INSERT INTO journal_entries (date, project_id, session_ids, headline, summary, topics, generated_at, model_used)
+      VALUES ('2026-02-20', 'myapp', '["s-1"]', 'Old headline', 'Stale summary', '[]', datetime('now'), 'test-model');
+    `);
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("includes an already-summarized group when its date is named explicitly", () => {
+    // A day that is still being worked on has a stale entry; naming the date is
+    // a deliberate request to regenerate it.
+    const groups = groupSessionsByDateAndProject(db, "2026-02-20");
+    expect(groups.length).toBe(1);
+    expect(groups[0]!.date).toBe("2026-02-20");
+  });
+
+  test("still skips already-summarized groups when no date is named", () => {
+    expect(groupSessionsByDateAndProject(db).length).toBe(0);
+  });
+
+  test("does not return other dates when one date is named", () => {
+    expect(groupSessionsByDateAndProject(db, "2026-02-19").length).toBe(0);
+  });
+});

--- a/src/summarize.ts
+++ b/src/summarize.ts
@@ -223,16 +223,18 @@ export function groupSessionsByDateAndProject(
     }
   }
 
-  // Filter out already-summarized combos
   const result: SessionGroup[] = [];
   for (const group of groups.values()) {
-    const key = `${group.date}|${group.projectId}`;
-    if (!summarized.has(key)) {
-      // Apply filterDate check against logical date
-      if (!filterDate || group.date === filterDate) {
-        result.push(group);
-      }
-    }
+    // Apply the date filter against the logical date.
+    if (filterDate && group.date !== filterDate) continue;
+
+    // Skip combos that already have an entry — unless the caller named the date
+    // outright, which is a deliberate request to regenerate it. A day still being
+    // worked on gets summarized long before it is over, and without this there is
+    // no way to refresh it short of deleting the row by hand.
+    if (!filterDate && summarized.has(`${group.date}|${group.projectId}`)) continue;
+
+    result.push(group);
   }
 
   return result;


### PR DESCRIPTION
A day gets summarized long before it is over, and there was no way to refresh that entry afterwards.

Group selection filtered out every `(date, project)` that already had an entry, and the `--date` check was applied *inside* that guard. So once the current day had an entry, neither `--all` nor `--date <today>` would revisit it — the only way to fold in the rest of the day's work was deleting the row by hand:

```sh
sqlite3 notebook.db "DELETE FROM journal_entries WHERE date='...' AND project_id='...'"
```

Naming a date is now treated as a deliberate request to regenerate it.

- `--all` is **unchanged**: it still only visits dates with no entry, so routine incremental runs never rewrite existing work.
- `--date` regenerates, replacing what's there. Pair with `--project` to narrow it to one project.

Persistence was already an upsert, so a regenerated entry replaces the old one in place rather than duplicating.

## Testing

95 tests pass, typecheck clean. Written test-first — three tests, one for the new behaviour and two pinning the existing behaviour so the guard can't be loosened by accident:

- an already-summarized group is returned when its date is named explicitly
- already-summarized groups are still skipped when no date is named
- naming one date does not return others

Branches from `main`; independent of #19, #20 and #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)