### PR TITLE
contrib: nightly launchd job for OpenCode day summaries

### DIFF
--- a/contrib/nightly-opencode/README.md
+++ b/contrib/nightly-opencode/README.md
@@ -1,0 +1,73 @@
+# Nightly OpenCode summaries (macOS / launchd)
+
+Regenerates the previous day's journal entries for every project that had
+OpenCode activity, once a day, unattended.
+
+Useful because OpenCode sessions arrive through the staging adapter rather than
+as files on disk, so they are only picked up when `ingest` runs — and because a
+day summarized while you are still working in it is summarized incomplete.
+
+## Requirements
+
+- The OpenCode source adapter, enabled in `config.json`
+- `summarize --date` regenerating an existing entry (rather than skipping it)
+- `bun`, `sqlite3`, `python3`, and the `opencode` CLI on `PATH`
+
+## Install
+
+```sh
+cp summarize-opencode-day.sh ~/.config/engineering-notebook/
+chmod +x ~/.config/engineering-notebook/summarize-opencode-day.sh
+
+sed "s|__HOME__|$HOME|g" com.engineering-notebook.nightly.plist \
+  > ~/Library/LaunchAgents/com.engineering-notebook.nightly.plist
+
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.engineering-notebook.nightly.plist
+```
+
+Verify it registered, and check the schedule launchd actually recorded:
+
+```sh
+launchctl list | grep engineering-notebook
+launchctl print gui/$UID/com.engineering-notebook.nightly | grep -E '"Hour"|"Minute"'
+```
+
+Run it by hand for a given day — worth doing once before trusting the schedule:
+
+```sh
+~/.config/engineering-notebook/summarize-opencode-day.sh 2026-07-31
+tail -30 ~/.config/engineering-notebook/nightly.log
+```
+
+To test it the way launchd will actually run it, with a minimal environment:
+
+```sh
+env -i HOME="$HOME" PATH=/usr/bin:/bin /bin/zsh \
+  ~/.config/engineering-notebook/summarize-opencode-day.sh
+```
+
+## Why 05:05
+
+`day_start_hour` (default `5`) means a logical day runs 05:00 to 05:00, so
+"yesterday" is not over until 05:00 today. A job at 00:01 would summarize a day
+that still has five hours left in it, and those hours would then be locked out.
+05:05 is the first moment the previous day is complete.
+
+The script honours whatever `day_start_hour` is configured, reading it from
+`config.json` and selecting sessions by logical date. Selecting on the calendar
+date instead both picks projects whose work belongs to the previous day and
+misses projects whose work belongs to this one.
+
+## Scope and caveats
+
+- **Projects, not sessions.** Journal entries are keyed by `(date, project)`, so
+  a project you used with both OpenCode and Claude Code on the same day gets one
+  entry covering both. The script selects *projects that had OpenCode activity*;
+  it cannot summarize OpenCode sessions in isolation.
+- **The checkout matters.** It runs `bun src/index.ts` from `NOTEBOOK_REPO`, so
+  whatever branch is checked out there is what runs.
+- **Secrets stay out of the plist.** The script sources `~/.zshenv`, so an API
+  key referenced by `summary_provider.api_key_env` is picked up from your shell
+  environment rather than being copied into a file launchd reads.
+- **Logs** go to `~/.config/engineering-notebook/nightly.log`, self-trimming at
+  1 MB. launchd's own stdout/stderr go to `nightly.launchd.log`.

--- a/contrib/nightly-opencode/com.engineering-notebook.nightly.plist
+++ b/contrib/nightly-opencode/com.engineering-notebook.nightly.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template. Replace __HOME__ with your home directory before installing:
+
+    sed "s|__HOME__|$HOME|g" com.engineering-notebook.nightly.plist \
+      > ~/Library/LaunchAgents/com.engineering-notebook.nightly.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.engineering-notebook.nightly</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>__HOME__/.config/engineering-notebook/summarize-opencode-day.sh</string>
+    </array>
+
+    <!--
+      05:05, just after day_start_hour (default 5) closes the previous logical
+      day. Running at midnight instead would miss work done between 00:00 and
+      05:00, which belongs to the day that is being summarized.
+    -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>5</integer>
+        <key>Minute</key>
+        <integer>5</integer>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.config/engineering-notebook/nightly.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.config/engineering-notebook/nightly.launchd.log</string>
+</dict>
+</plist>

--- a/contrib/nightly-opencode/summarize-opencode-day.sh
+++ b/contrib/nightly-opencode/summarize-opencode-day.sh
@@ -1,0 +1,70 @@
+#!/bin/zsh
+#
+# Summarize a day's OpenCode work.
+#
+# Ingests first, so OpenCode sessions are staged out of OpenCode's SQLite
+# database, then regenerates the journal entry for every project that had
+# OpenCode activity on the target day.
+#
+# Usage:  summarize-opencode-day.sh [YYYY-MM-DD]
+#         Defaults to yesterday. See README.md for the launchd wiring.
+#
+# Environment:
+#   NOTEBOOK_REPO    checkout to run from   (default ~/Developer/engineering-notebook)
+#   NOTEBOOK_CONFIG  config directory       (default ~/.config/engineering-notebook)
+
+set -uo pipefail
+
+# launchd starts with a minimal environment. Sourcing the shell env picks up
+# whatever the configured summary provider needs (e.g. an API key variable).
+[[ -f "$HOME/.zshenv" ]] && source "$HOME/.zshenv"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+REPO="${NOTEBOOK_REPO:-$HOME/Developer/engineering-notebook}"
+CONFIG_DIR="${NOTEBOOK_CONFIG:-$HOME/.config/engineering-notebook}"
+DB="$CONFIG_DIR/notebook.db"
+LOG="$CONFIG_DIR/nightly.log"
+
+exec >> "$LOG" 2>&1
+
+# Trim the log rather than letting it grow without bound.
+if [[ -f "$LOG" && $(wc -c < "$LOG") -gt 1048576 ]]; then
+  tail -c 262144 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+fi
+
+DAY="${1:-$(date -v-1d +%Y-%m-%d)}"
+echo "=== $(date '+%Y-%m-%d %H:%M:%S') — OpenCode summary for $DAY ==="
+
+cd "$REPO" || { echo "FAIL: $REPO not found"; exit 1; }
+
+if ! bun src/index.ts ingest --force; then
+  echo "FAIL: ingest failed"
+  exit 1
+fi
+
+# Select by *logical* date, the same way summarize groups sessions. With
+# day_start_hour at 5, a session begun at 01:00 belongs to the previous day;
+# selecting on the calendar date would pick projects whose work summarize then
+# declines to group, and miss projects whose work it does.
+HOUR=$(python3 -c "import json;print(json.load(open('$CONFIG_DIR/config.json')).get('day_start_hour',5))")
+
+projects=$(sqlite3 "$DB" \
+  "SELECT DISTINCT project_id FROM sessions
+   WHERE id LIKE 'ses_%'
+     AND date(datetime(started_at, '-$HOUR hours')) = '$DAY';")
+
+if [[ -z "$projects" ]]; then
+  echo "no OpenCode sessions for $DAY — nothing to summarize"
+  echo "=== done ==="
+  exit 0
+fi
+
+failed=0
+echo "$projects" | while IFS= read -r project; do
+  [[ -n "$project" ]] || continue
+  echo "--- $project ---"
+  bun src/index.ts summarize --date "$DAY" --project "$project" || failed=1
+done
+
+echo "=== done (exit $failed) ==="
+exit $failed


### PR DESCRIPTION
Packaging for a workflow the CLI already supports. **Nothing in `src/` changes** — this adds a script, a launchd plist template and setup notes under `contrib/`.

## Why

Two things push toward one unattended run per day:

- OpenCode sessions only reach the journal when `ingest` runs the staging adapter, so they lag until someone runs it.
- A day summarized while you are still working in it is summarized incomplete, and stays that way.

Running once, just after the day is genuinely over, addresses both.

## Depends on

- **#20** — the OpenCode source adapter (the script's whole subject)
- **#22** — `--date` regenerating an existing entry; without it the nightly run is a no-op on any day that was already summarized

Branched from `main` and touches no shared files, so it can merge in any order relative to those — it simply does nothing useful until both land.

## Two details that are easy to get wrong

**Sessions are selected by *logical* date**, reading `day_start_hour` from config, because that is how `summarize` groups them. Selecting on the calendar date is wrong in both directions: it picks projects whose work belongs to the previous day, and misses projects whose work belongs to this one. I hit exactly this while testing — a project with sessions at 00:07 and 01:48 was selected for the wrong day and summarized nothing.

**The job runs at 05:05, not midnight.** With `day_start_hour` at 5 a logical day runs 05:00 to 05:00, so a midnight run summarizes a day with five hours still left in it — and, because the entry then exists, freezes it that way.

## Scope

Entries are keyed by `(date, project)`, so a project used with both OpenCode and Claude Code on the same day yields one entry covering both. The script selects *projects that had OpenCode activity*; summarizing OpenCode sessions in isolation would need source-aware grouping in the tool itself. The README says so plainly rather than implying a cleaner separation than exists.

Secrets stay out of the plist — the script sources the shell environment, so a key named by `summary_provider.api_key_env` is never copied into a file launchd reads.

## Testing

Run end-to-end on macOS against a live corpus: a populated day (regenerating entries across five projects, with trivial ones correctly skipped), an empty day (clean no-op exit), and under `env -i` with a stripped `PATH` to mimic launchd's minimal environment rather than a login shell. The `launchctl` registration and recorded calendar interval were verified after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)